### PR TITLE
Fix versioning by only using tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VER := $(shell git describe --tags|awk -F'[.-]' '{print $$1 "." $$2 "." $$4}')
+VER := $(shell git describe --tags)
 NAME := bandwagon
 PACKAGE := gravitational.io/$(NAME):$(VER)
 OPS_URL ?= https://opscenter.localhost.localdomain:33009


### PR DESCRIPTION
Gravity versioning scheme used previously does not play well with tag values - so simply use the tag as version.
