### PR TITLE
Remove remote support code.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ run: build
 
 
 #
-# The 'app' target builds bandwagon Telekube package in the current directory, for example:
+# The 'app' target builds bandwagon package in the current directory, for example:
 #
 #   $ VERSION=1.2.0 make app
 #

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Telekube Final Install Step Application
+# Gravity Final Install Step Application
 
-Bandwagon is the application you can fork, customize and tweak to set up last installation step of Telekube install wizard.
+Bandwagon is the application you can fork, customize and tweak to set up last installation step of Gravity install wizard.
 
 ### Making Changes
 
@@ -43,7 +43,7 @@ installer:
 
 ### Creating a Local User after an Automatic/Unattended Installation
 
-After installing bandwagon with Telekube as part of an automatic/unattended
+After installing bandwagon with Gravity as part of an automatic/unattended
 installation, you'll need to create a local user account and password to log
 into the Gravity web app. See [Configuring Users](https://gravitational.com/gravity/docs/cluster/#configuring-users-tokens)
 documentation section for the information on how to create a user.

--- a/lib/api/handlers.go
+++ b/lib/api/handlers.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017 Gravitational, Inc.
+Copyright 2017-2019 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -21,9 +21,9 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/gorilla/mux"
-
 	"github.com/gravitational/bandwagon/lib/gravity"
+
+	"github.com/gorilla/mux"
 	"github.com/gravitational/trace"
 )
 
@@ -92,7 +92,7 @@ func completeHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = gravity.CompleteInstall(req.Support)
+	err = gravity.CompleteInstall()
 	if err != nil {
 		replyError(w, err.Error())
 		return
@@ -107,8 +107,6 @@ type CompleteRequest struct {
 	Email string `json:"email"`
 	// Password is the password of the admin user.
 	Password string `json:"password"`
-	// Support enables/disables remote support with Gravitational OpsCenter.
-	Support bool `json:"support"`
 }
 
 const (


### PR DESCRIPTION
A couple of cleanups/updates to Bandwagon:

* Remove code related to remote support management since we got rid of it.
* Rename Telekube to Gravity in the docs.

Refs https://github.com/gravitational/gravity.e/issues/4120.