### PR TITLE
Add CONTRIBUTING and CODE_OF_CONDUCT

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at info@goteleport.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing
+
+Bandwagon is an open source project.
+
+It is the work of many contributors. We appreciate your help!
+
+We follow a [code of conduct](./CODE_OF_CONDUCT.md).
+
+## Filing an Issue
+
+Security issues should be reported directly to security@goteleport.com.
+
+Bandwagon uses [Gravity's issue tracker]((https://github.com/gravitational/gravity/issues).
+
+If you are unsure if you've found a bug, search the tracker first.
+
+Once you know you have a issue, fill out all sections of the
+one of the templates at https://github.com/gravitational/gravity/issues/new/choose.
+
+Gravity contributors will triage the issue.
+
+## Contributing A Patch
+
+If you're working on an existing issue, respond to the issue and express
+interest in working on it. This helps other people know that the issue is
+active, and hopefully prevents duplicated efforts.
+
+If you want to work on a new idea of relatively small scope:
+
+1. Submit an issue describing the proposed change and the implementation.
+2. The repo owners will respond to your issue promptly.
+3. Write your code, test your changes and _communicate_ with us as you're
+moving forward.
+4. Submit a pull request from your fork.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Gravity Final Install Step Application
 
-Bandwagon is the application you can fork, customize and tweak to set up last installation step of Gravity install wizard.
+Bandwagon is an application you can fork and customize to add a final step to the [Gravity](https://github.com/gravitational/gravity) install wizard,
+as described in the [custom installer](https://gravitational.com/gravity/docs/pack/#custom-installation-screen) documentation.
 
 ### Making Changes
 
@@ -11,7 +12,7 @@ make run
 
 If something is not working, do `make clean` and then repeat the commands above.
 
-For Web UI development, [use this instructions](web/README.md) to start a local development server with hot updates.
+For Web UI development, [use these instructions](web/README.md) to start a local development server with hot updates.
 
 
 ### Enabling It In Your Application
@@ -47,3 +48,10 @@ After installing bandwagon with Gravity as part of an automatic/unattended
 installation, you'll need to create a local user account and password to log
 into the Gravity web app. See [Configuring Users](https://gravitational.com/gravity/docs/cluster/#configuring-users-tokens)
 documentation section for the information on how to create a user.
+
+
+## Contributing
+
+The most common use of bandwagon shouldn't require merging changes back into the mainline,
+but instead bundling the edited bandwagon in a [cluster image](https://goteleport.com/gravity/docs/pack/).
+If you would like to upstream your changes, check out our [contributing guidelines](./CONTRIBUTING.md) and [Code of Conduct](./CODE_OF_CONDUCT.md).


### PR DESCRIPTION
In anticipation of increased outside contribution, add our standard
contributing documentation. Also clear up some wording and add useful
links to the README.md.

Part of a series contributing to https://github.com/gravitational/gravity/pull/2429